### PR TITLE
Refactoring of vectorized tick code complete.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@
 
 # QT files
 *.moc
-
-# binary file
-demo/demo

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char*argv[]) {
 				ParseScenario parser(scenefile);
 				model.setup(parser.getAgents(), parser.getWaypoints(), Ped::SEQ);
 				Ped::Vagent v(model);
-				model.addVagent(v);
+				model.addVagent(&v);
 				PedSimulation simulation(model, mainwindow);
 				// Simulation mode to use when profiling (without any GUI)
 				std::cout << "Running reference version...\n";
@@ -126,7 +126,7 @@ int main(int argc, char*argv[]) {
 				ParseScenario parser(scenefile);
 				model.setup(parser.getAgents(), parser.getWaypoints(), implementation_to_test);
 				Ped::Vagent v(model);
-				model.addVagent(v);
+				model.addVagent(&v);
 				PedSimulation simulation(model, mainwindow, vagents);
 				// Simulation mode to use when profiling (without any GUI)
 				std::cout << "Running target version...\n";
@@ -146,7 +146,7 @@ int main(int argc, char*argv[]) {
 		{
 
 			Ped::Vagent v(model);
-			model.addVagent(v);
+			model.addVagent(&v);
 			PedSimulation simulation(model, mainwindow);
 
 			cout << "Demo setup complete, running ..." << endl;

--- a/libpedsim/ped_agent.cpp
+++ b/libpedsim/ped_agent.cpp
@@ -8,9 +8,8 @@
 #include "ped_agent.h"
 #include "ped_waypoint.h"
 #include <math.h>
-#include <emmintrin.h>
-#include <stdlib.h>
 
+#include <stdlib.h>
 
 Ped::Tagent::Tagent(int posX, int posY) {
 	Ped::Tagent::init(posX, posY);
@@ -27,139 +26,49 @@ void Ped::Tagent::init(int posX, int posY) {
 	lastDestination = NULL;
 }
 
-void Ped::Tagent::computeNextDesiredPosition(std::vector<Ped::Tagent*> agents, Ped::Vagent *vagents, int i) {
-	__m128i _null, d_x, d_y, mask1, mask2;
-
-	_null = _mm_set1_epi32(NULL); //Oklart om funkar
-	_ones = _mm_set1_epi32(1); //TODO: 
-	d_x = _mm_load_si128(&vagents->destinationX + i); //destination x
-	d_y = _mm_load_si128(&vagents->destinationY + i); //destination y
-
-	//mask1 if dest_x == null
-	mask1 = _mm_cmpeq_epi32(d_x, _null); // m1 = |11..11|00..00|11..11|00..00| if statement true or false for all 32 bits
-	mask2 = _mm_cmpeq_epi32(d_y, _null); // m1 = |00..00|00..00|11..11|00..00|
-
-	mask1 = _mm_and_si128(mask1, mask2); // m1 = |11.11|00..00|11..11|00..00|
-
-		//int a = _mm_movemask_epi8 (mask1)
-
-	if (_mm_movemask_epi8(mask1) == _ones) {
-		// no destination, no need to if destination == NULL { return}
+void Ped::Tagent::computeNextDesiredPosition() {
+	destination = getNextDestination();
+	if (destination == NULL) {
+		// no destination, no need to
 		// compute where to move to
 		return;
 	}
 
-	__m128i t_x, t_y, dest_id, ldest_id; //ints
-	__m128 d_r, t_a, t_b, ps_x, ps_y; //single floating point
-
-	t_x = _mm_load_si128(&vagents->x + i);
-	t_y = _mm_load_si128(&vagents->y + i);
-	d_x = _mm_sub_epi32(d_x, t_x); //d_x is now diffX = destinationx - x
-	d_y = _mm_sub_epi32(d_x, t_y); //same
-
-	ps_x = _mm_castsi128_ps(d_x);
-	ps_y = _mm_castsi128_ps(d_y);
-
-	t_a = _mm_mul_ps(ps_x, ps_x); //temporary a = diffX*diffX
-	t_b = _mm_mul_ps(ps_y, ps_y); //temporary b diffY*diffY
-
-	t_a = _mm_add_ps(t_a, t_b); // diffX*diffX - diffY*diffY
-
-	t_a = _mm_sqrt_ps(t_a); // len = sqrt(diffX*diffX - diffY*diffY)
-
-	ps_x = _mm_div_ps(ps_x, t_a); //second part of (int)round(x + diffX / len);
-	ps_y = _mm_div_ps(ps_y, t_a);
-
-	_mm_castps_si128(ps_x); //casts to int from float 
-	_mm_castps_si128(ps_y);
-
-	t_x = _mm_add_epi32(d_x, t_x); //t_x is now the new x
-	t_y = _mm_add_epi32(d_y, t_y); //t_y is now the new y
-
-
-	//|11.11|00..00|11..11|00..00|
-	t_x = _mm_and_si128(t_x, mask1);
-	t_y = _mm_and_si128(t_y, mask1);
-
-
-	_mm_store_si128(&vagents->destinationX + i, t_x);
-	_mm_store_si128(&vagents->destinationY + i, t_y);
-
-	for (k = 0; k < 4; k++) {
-		agents[i]->setX(&vagents->destinationX + i + k);
-		agents[i]->setY(&vagents->destinationY + i + k);
-	}
+	double diffX = destination->getx() - x;
+	double diffY = destination->gety() - y;
+	double len = sqrt(diffX * diffX + diffY * diffY);
+	desiredPositionX = (int)round(x + diffX / len);
+	desiredPositionY = (int)round(y + diffY / len);
 }
 
 void Ped::Tagent::addWaypoint(Twaypoint* wp) {
 	waypoints.push_back(wp);
 }
 
-void Ped::Tagent::destinationReached(Ped::Vagent* agents, int i) {
-
-	__m128i _null, d_x, d_y, d_r, _reached, _x, _y, _len;
-	__m128 ps_x, ps_y, t_a, t_b;
-	// compute if agent reached its current destination
-
-	d_x = _mm_load_si128(&vagents->destinationX + i); //destination x
-	d_y = _mm_load_si128(&vagents->destinationY + i); //destination y
-	d_r = _mm_load_si128(&vagents->destinationR + i); //destination r
-	_x = _mm_load_si128(&vagents->x + i);
-	_y = _mm_load_si128(&vagents->y + i);
-
-	d_x = _mm_sub_epi32(d_x, _x); //d_x is now diffX = destinationx - x
-	d_y = _mm_sub_epi32(d_x, _y); //same
-
-	ps_x = _mm_castsi128_ps(d_x); //float version of diffx and diffy
-	ps_y = _mm_castsi128_ps(d_y);
-
-	t_a = _mm_mul_ps(ps_x, ps_x); //temporary a = diffX * diffX
-	t_b = _mm_mul_ps(ps_y, ps_y); //temporary b = diffY * diffY
-
-	t_a = _mm_add_ps(t_a, t_b); // diffX*diffX + diffY*diffY
-
-	t_a = _mm_sqrt_ps(t_a); // len = sqrt(diffX*diffX - diffY*diffY)
-
-	_len = _mm_castps_si128(t_a); //cast to int
-
-	_reached = _mm_cmpgt_epi32(d_r, _len); //mask telling if agent
-	_mm_store_si128(&vagents->reachedDestination + i, _reached);
-}
-
-
-void Ped::Tagent::getNextDestination(Ped::Vagent* agents, int i) {
+Ped::Twaypoint* Ped::Tagent::getNextDestination() {
 	Ped::Twaypoint* nextDestination = NULL;
-	int k = i + 4;
-	int newi = i;
-	for (newi; newi < k; newi++) {
-		int agentReachedDestination = agents->destinationReached + newi;
-		bool check;
-		if (agentReachedDestination > 0) {
-		check = true;
-	    }
-		else {
-			check = false;
-		}
-		if ((check || (agents->destinationX + newi) == NULL) && !waypoints.empty()) { //waypointsize == 0
-			// Case 1: agent has reached destination (or has no current destination);
-			// get next destination if available
-			waypoints.push_back(destination);
-			nextDestination = waypoints.front();
-			waypoints.pop_front();
-			agents->destinationX + newi = nextDestination->getx();
-			agents->destinationY + newi = nextDestination->gety();
-			agents->destinationR + newi = nextDestination->getr();
-			agents->destinationID + newi = nextDestination->getid();
-			//uppdatera pekarvärde!
-		}
-		else {
-			// Case 2: agent has not yet reached destination, continue to move towards
-			// current destination
-			agents->destinationX + newi = nextDestination->getx();
-			agents->destinationY + newi = nextDestination->gety();
-			agents->destinationR + newi = nextDestination->getr();
-			agents->destinationID + newi = nextDestination->getid();
-			//nextDestination = destination;
-		}
+	bool agentReachedDestination = false;
+
+	if (destination != NULL) {
+		// compute if agent reached its current destination
+		double diffX = destination->getx() - x;
+		double diffY = destination->gety() - y;
+		double length = sqrt(diffX * diffX + diffY * diffY);
+		agentReachedDestination = length < destination->getr();
 	}
+
+	if ((agentReachedDestination || destination == NULL) && !waypoints.empty()) {
+		// Case 1: agent has reached destination (or has no current destination);
+		// get next destination if available
+		waypoints.push_back(destination);
+		nextDestination = waypoints.front();
+		waypoints.pop_front();
+	}
+	else {
+		// Case 2: agent has not yet reached destination, continue to move towards
+		// current destination
+		nextDestination = destination;
+	}
+
+	return nextDestination;
 }

--- a/libpedsim/ped_agent.h
+++ b/libpedsim/ped_agent.h
@@ -18,7 +18,6 @@
 
 #include <vector>
 #include <deque>
-#include <emmintrin.h>
 
 using namespace std;
 
@@ -34,7 +33,6 @@ namespace Ped {
 		int getDesiredX() const { return desiredPositionX; }
 		int getDesiredY() const { return desiredPositionY; }
 
-
 		// Sets the agent's position
 		void setX(int newX) { x = newX; }
 		void setY(int newY) { y = newY; }
@@ -48,12 +46,13 @@ namespace Ped {
 		int getY() const { return y; };
 
 		// Adds a new waypoint to reach for this agent
-		void addWaypoint(Twaypoint* wp);
+		void addWaypoint(Twaypoint* wp);  
 
-		// get detstination coordinates
+        // get destination coordinates
 		Twaypoint* getDest() const { return destination; };
 
-		deque<Twaypoint*>* getWaypointsPointer() { return &waypoints; };
+        // get waypoints deque
+		deque<Twaypoint*> getWaypoints() { return waypoints; }; 
 
 	private:
 		Tagent() {};
@@ -71,8 +70,6 @@ namespace Ped {
 
 		// The last destination
 		Twaypoint* lastDestination;
-
-		void destinationReached();
 
 		// The queue of all destinations that this agent still has to visit
 		deque<Twaypoint*> waypoints;

--- a/libpedsim/ped_model.h
+++ b/libpedsim/ped_model.h
@@ -53,10 +53,10 @@ namespace Ped{
 		int const * const * getHeatmap() const { return blurred_heatmap; };
 		int getHeatmapSize() const;
 
-		Ped::Vagent vagents;
+		Ped::Vagent *vagents;
 
 		// Adds a Vagent to the model. // STUDENT MADE //
-		void addVagent(Ped::Vagent v) { vagents = v; }
+		void addVagent(Ped::Vagent *v) { vagents = v; }
 
 	private:
 

--- a/libpedsim/vector_agents.cpp
+++ b/libpedsim/vector_agents.cpp
@@ -6,10 +6,6 @@
 #include <stdlib.h>
 #include <emmintrin.h>
 
-Ped::Vagent::Vagent(Ped::Model mod) {
-	Ped::Vagent::init(mod);
-}
-
 void Ped::Vagent::init(Ped::Model mod) {
 
     std::vector<Tagent*> agents = mod.getAgents();
@@ -73,6 +69,10 @@ void Ped::Vagent::init(Ped::Model mod) {
         *d7 = NULL;
         *d8 = NULL;
     }
+}
+
+Ped::Vagent::Vagent(Ped::Model mod) {
+	Ped::Vagent::init(mod);
 }
 
 void Ped::Vagent::destinationReached(int i) {

--- a/libpedsim/vector_agents.cpp
+++ b/libpedsim/vector_agents.cpp
@@ -6,10 +6,6 @@
 #include <stdlib.h>
 #include <emmintrin.h>
 
-
-
-
-
 Ped::Vagent::Vagent(Ped::Model mod) {
 	Ped::Vagent::init(mod);
 }
@@ -32,7 +28,6 @@ void Ped::Vagent::init(Ped::Model mod) {
 	float *LastdestinationX = (float *)_mm_malloc(s * sizeof(float), 16); // pekare till double:s på rad.
 	float *LastdestinationY = (float *)_mm_malloc(s * sizeof(float), 16); // pekare till double:s på rad.
 	float *LastdestinationR = (float *)_mm_malloc(s * sizeof(float), 16); // pekare till double:S på rad.
-
 
     Ped::Tagent* tmp;
 
@@ -78,4 +73,150 @@ void Ped::Vagent::init(Ped::Model mod) {
         *d7 = NULL;
         *d8 = NULL;
     }
+}
+
+void Ped::Vagent::destinationReached(int i) {
+
+	__m128i _null, d_x, d_y, d_r, _reached, _x, _y, _len;
+	__m128 ps_x, ps_y, t_a, t_b;
+	// compute if agent reached its current destination
+
+	d_x = _mm_load_si128(this->destinationX + i); //destination x
+	d_y = _mm_load_si128(this->destinationY + i); //destination y
+	d_r = _mm_load_si128(this->destinationR + i); //destination r
+	_x = _mm_load_si128(this->x + i);
+	_y = _mm_load_si128(this->y + i);
+
+	d_x = _mm_sub_epi32(d_x, _x); //d_x is now diffX = destinationx - x
+	d_y = _mm_sub_epi32(d_x, _y); //same
+
+	ps_x = _mm_castsi128_ps(d_x); //float version of diffx and diffy
+	ps_y = _mm_castsi128_ps(d_y);
+
+	t_a = _mm_mul_ps(ps_x, ps_x); //temporary a = diffX * diffX
+	t_b = _mm_mul_ps(ps_y, ps_y); //temporary b = diffY * diffY
+
+	t_a = _mm_add_ps(t_a, t_b); // diffX*diffX + diffY*diffY
+
+	t_a = _mm_sqrt_ps(t_a); // len = sqrt(diffX*diffX - diffY*diffY)
+
+	_len = _mm_castps_si128(t_a); //cast to int
+
+	_reached = _mm_cmpgt_epi32(d_r, _len); //mask telling if agent
+	_mm_store_si128(this->reachedDestination + i, _reached);
+}
+
+void Ped::Vagent::computeNextDesiredPosition(std::vector<Ped::Tagent*> tagents, int i) {
+	__m128i _null, d_x, d_y, mask1, mask2;
+
+	_null = _mm_set1_epi32(NULL); //Oklart om funkar
+	_ones = _mm_set1_epi32(1); //TODO: 
+	d_x = _mm_load_si128(this->destinationX + i); //destination x
+	d_y = _mm_load_si128(this->destinationY + i); //destination y
+
+	//mask1 if dest_x == null
+	mask1 = _mm_cmpeq_epi32(d_x, _null); // m1 = |11..11|00..00|11..11|00..00| if statement true or false for all 32 bits
+	mask2 = _mm_cmpeq_epi32(d_y, _null); // m1 = |00..00|00..00|11..11|00..00|
+
+	mask1 = _mm_and_si128(mask1, mask2); // m1 = |11.11|00..00|11..11|00..00|
+
+		//int a = _mm_movemask_epi8 (mask1)
+
+	if (_mm_movemask_epi8(mask1) == _ones) {
+		// no destination, no need to if destination == NULL { return}
+		// compute where to move to
+		return;
+	}
+
+	__m128i t_x, t_y, dest_id, ldest_id; //ints
+	__m128 d_r, t_a, t_b, ps_x, ps_y; //single floating point
+
+	t_x = _mm_load_si128(this->x + i);
+	t_y = _mm_load_si128(this->y + i);
+	d_x = _mm_sub_epi32(d_x, t_x); //d_x is now diffX = destinationx - x
+	d_y = _mm_sub_epi32(d_x, t_y); //same
+
+	ps_x = _mm_castsi128_ps(d_x);
+	ps_y = _mm_castsi128_ps(d_y);
+
+	t_a = _mm_mul_ps(ps_x, ps_x); //temporary a = diffX*diffX
+	t_b = _mm_mul_ps(ps_y, ps_y); //temporary b diffY*diffY
+
+	t_a = _mm_add_ps(t_a, t_b); // diffX*diffX - diffY*diffY
+
+	t_a = _mm_sqrt_ps(t_a); // len = sqrt(diffX*diffX - diffY*diffY)
+
+	ps_x = _mm_div_ps(ps_x, t_a); //second part of (int)round(x + diffX / len);
+	ps_y = _mm_div_ps(ps_y, t_a);
+
+	_mm_castps_si128(ps_x); //casts to int from float 
+	_mm_castps_si128(ps_y);
+
+	t_x = _mm_add_epi32(d_x, t_x); //t_x is now the new x
+	t_y = _mm_add_epi32(d_y, t_y); //t_y is now the new y
+
+
+	//|11.11|00..00|11..11|00..00|
+	t_x = _mm_and_si128(t_x, mask1);
+	t_y = _mm_and_si128(t_y, mask1);
+
+
+	_mm_store_si128(this->destinationX + i, t_x);
+	_mm_store_si128(this->destinationY + i, t_y);
+
+	for (int k = 0; k < 4; k++) {
+        float *tmpDestX = this->destinationX + (i + k);
+        float *tmpDestY = this->destinationY + (i + k);
+		tagents[i]->setX(*tmpDestX);
+		tagents[i]->setY(*tmpDestY);
+	}
+}
+
+void Ped::Vagent::getNextDestination(std::vector<Ped::Tagent*> tagents, int i) {
+	Ped::Twaypoint* nextDestination = NULL;
+	int k = i + 4;
+	for (i; i < k; i++) {
+        Ped::Tagent* agent = tagents[i];
+        // get the waypoints deque of the agent.
+        deque<Twaypoint*> waypoints = agent->getWaypoints();
+		int agentReachedDestination = *this->reachedDestination + i;   /// TODO: is this correct?
+		bool check;
+		if (agentReachedDestination > 0) {
+		    check = true;
+	    }
+		else {
+			check = false;
+		}
+		if ((check || (this->destinationX + i) == NULL) && !waypoints.empty()) { //waypointsize == 0
+			// Case 1: agent has reached destination (or has no current destination);
+			// get next destination if available
+			waypoints.push_back(agent->getDest());
+			nextDestination = waypoints.front();
+			waypoints.pop_front();
+
+			float *tmpDestX = this->destinationX + i;
+            float *tmpDestY = this->destinationY + i;
+            float *tmpDestR = this->destinationR + i;
+            int *tmpDestId = this->destinationId + i;
+            *tmpDestX = (float)nextDestination->getx();
+            *tmpDestY = (float)nextDestination->gety();
+            *tmpDestR = (float)nextDestination->getr();
+            *tmpDestId = (float)nextDestination->getid();
+			//uppdatera pekarvärde!
+		}
+		else {
+			// Case 2: agent has not yet reached destination, continue to move towards
+			// current destination
+			float *tmpDestX = this->destinationX + i;
+            float *tmpDestY = this->destinationY + i;
+            float *tmpDestR = this->destinationR + i;
+            int *tmpDestId = this->destinationId + i;
+            *tmpDestX = (float)nextDestination->getx();
+            *tmpDestY = (float)nextDestination->gety();
+            *tmpDestR = (float)nextDestination->getr();
+            *tmpDestId = (float)nextDestination->getid();
+
+			//nextDestination = destination; ////////// TODO: Är denna viktig?
+		}
+	}
 }

--- a/libpedsim/vector_agents.h
+++ b/libpedsim/vector_agents.h
@@ -4,10 +4,16 @@
 #include <vector>
 #include <deque>
 #include <emmintrin.h>
+
+#include "ped_model.h"
+
 using namespace std;
 
 namespace Ped {
-	class Vagent {
+        class Model;
+        class Tagent;
+	class Vagent 
+        {
 	public:
 	Vagent(Ped::Model mod);
 

--- a/libpedsim/vector_agents.h
+++ b/libpedsim/vector_agents.h
@@ -9,7 +9,11 @@ using namespace std;
 namespace Ped {
 	class Vagent {
 	public:
-		Vagent(Ped::Model mod);
+	Vagent(Ped::Model mod);
+
+        ///////////////////////////////////////////////////////////
+        /// Attributes
+        ///////////////////////////////////////////////////////////
 
         int *x; // pekare till int:s på rad.
         int *y; // pekare till int:s på rad.
@@ -24,9 +28,22 @@ namespace Ped {
         float *LastdestinationY; // pekare till double:s på rad.
         float *LastdestinationR; // pekare till double:S på rad.
 
+        ///////////////////////////////////////////////////////////
+        /// Methods
+        ///////////////////////////////////////////////////////////
+
+        // Update the position according to get closer
+	// to the current destination
+	void computeNextDesiredPosition(std::vector<Ped::Tagent*> tagents, int i);
+
+	void destinationReached(int i);
+
+        void getNextDestination(std::vector<Ped::Tagent*> tagents, int i);
+
 	private:
 
         void init(Ped::Model mod);
+
 	};
 }
 


### PR DESCRIPTION
I have refactored the vectorized code to be more structured, fixed some type errors, and made some quality of life changes. The main changes are as follows:

- Moved all vectorized versions of `computeNextDesiredPosition()`, `destinationReached()`, and `getNextDestination()` to now be part of the Vagent class. This for readability, but also to concentrate the logic to the struct it operates on. This also allows us to keep all the old functions in Tagent as it was before.

- Revert Tagent to have all the old logic. This mostly to not break anything. Still has `getDest()` and `getWaypoints()`

- Model now stores a pointer to the Vagent struct and not the whole struct itself as a Class Variable. Makes more sense memory wise.

- Updated all vector loads and stores to use a pointer (*) to memory and not a double-pointer (**). E.x `_mm_load_si128(&this->destinationX + i)` to `_mm_load_si128(this->destinationX + i)`. This might be wrong, so feel free to change back if thats the case.

- Updated all tick functions with the new logic.

- Broke out some pointer updates to use variable copies of the Vagent pointers. This is close to superstition, but sometimes casts (double to float in our case) when derefrencing pointers can be weird.
